### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/HTTPProxyServer.py
+++ b/src/HTTPProxyServer.py
@@ -272,7 +272,7 @@ def receive_body_chunked(sock, body_start):
 
 
 def send_msg(sock, code, msg):
-    sock.sendall(('HTTP/1.1 %d %s\r\n\r\n' % (code, msg)).encode('latin-1', 'strict'))
+    sock.sendall(('HTTP/1.1 {0:d} {1!s}\r\n\r\n'.format(code, msg)).encode('latin-1', 'strict'))
 
 
 class Request:

--- a/src/HTTPSConnectionHandler.py
+++ b/src/HTTPSConnectionHandler.py
@@ -72,7 +72,7 @@ class ManInTheMiddle:
         self.server_ssl_sock = None
 
     def start_hacking(self):
-        self.client_socket.sendall(('HTTP/1.1 %d %s\r\n\r\n' % (200, 'OK')).encode('latin-1', 'strict'))
+        self.client_socket.sendall(('HTTP/1.1 {0:d} {1!s}\r\n\r\n'.format(200, 'OK')).encode('latin-1', 'strict'))
         self.accept_client_conn()
 
     def accept_client_conn(self):

--- a/src2/HTTPProxyServer.py
+++ b/src2/HTTPProxyServer.py
@@ -272,7 +272,7 @@ def receive_body_chunked(sock, body_start):
 
 
 def send_msg(sock, code, msg):
-    sock.sendall(('HTTP/1.1 %d %s\r\n\r\n' % (code, msg)).encode('latin-1', 'strict'))
+    sock.sendall(('HTTP/1.1 {0:d} {1!s}\r\n\r\n'.format(code, msg)).encode('latin-1', 'strict'))
 
 
 class Request:

--- a/src2/HTTPSConnectionHandler.py
+++ b/src2/HTTPSConnectionHandler.py
@@ -52,7 +52,7 @@ OU = MyDivision
 
 def build_ssl_conns(client_socket, path):
     server_ssl_sock = build_server_conn(path)
-    client_socket.sendall(('HTTP/1.1 %d %s\r\n\r\n' % (200, 'OK')).encode('latin-1', 'strict'))
+    client_socket.sendall(('HTTP/1.1 {0:d} {1!s}\r\n\r\n'.format(200, 'OK')).encode('latin-1', 'strict'))
 
     cert_dict = server_ssl_sock.getpeercert()
     crt_dir = generate_fake_cert(cert_dict)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tylerwowen:mitm_proxy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tylerwowen:mitm_proxy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
